### PR TITLE
avoid warning for unrecognized field

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
     host: 
         description: 'Deploy host'
         required: true
+    port: 
+        description: 'Deploy port'
+        required: false
     path: 
         description: 'Path source on server'
         required: true


### PR DESCRIPTION
this will avoid:
`##[warning]Unexpected input(s) 'port', valid inputs are ['entryPoint', 'args', 'user', 'host', 'path', 'owner']`